### PR TITLE
Fix bug in Ajax, adds parent method

### DIFF
--- a/lib/assets/javascripts/esphinx/ajax.js
+++ b/lib/assets/javascripts/esphinx/ajax.js
@@ -48,8 +48,8 @@ Ajax = (function () {
                     if (args.params) {
                         url += "?";
 
-                        args.params.eachAttrs(function (v, i) {
-                            url += i + "=" + v + "&";
+                        args.params.recursiveEach(function (param) {
+                          url += param.name + "=" + param.value + "&";
                         });
 
                         url = url.slice(0, url.length - 1);

--- a/lib/assets/javascripts/esphinx/attribute.js
+++ b/lib/assets/javascripts/esphinx/attribute.js
@@ -14,8 +14,8 @@ var
                 var
                     self = this;
 
-                self.eachAttrs(function (domElement) {
-                    domElement.removeAttribute(attrName);
+                self.eachAttrs(function (node) {
+                    node.removeAttribute(attrName);
                 });
 
                 return self;
@@ -31,8 +31,8 @@ var
                 }
 
                 if (typeof value === "boolean" || value || value === "") {
-                    self.eachAttrs(function (domElement) {
-                        domElement.setAttribute(attrName, value);
+                    self.eachAttrs(function (node) {
+                        node.setAttribute(attrName, value);
                     });
 
                     return self;
@@ -55,8 +55,8 @@ var
                 }
 
                 if (typeof value === "boolean" || value || value === "") {
-                    self.eachAttrs(function (domElement) {
-                        domElement[propertyName] = value;
+                    self.eachAttrs(function (node) {
+                        node[propertyName] = value;
                     });
 
                     return self;

--- a/lib/assets/javascripts/esphinx/event.js
+++ b/lib/assets/javascripts/esphinx/event.js
@@ -9,12 +9,12 @@ var
 (function ($module) {
 
     var
-        domElements = [],
+        nodes = [],
         mappedListeners = {},
 
-        mapped = function (domElement) {
+        mapped = function (node) {
             var
-                index = domElements.indexPerEquivalence(domElement);
+                index = nodes.indexPerEquivalence(node);
 
             if (index) {
                 return true;
@@ -23,38 +23,38 @@ var
             return false;
         },
 
-        mapEventListener = function (domElement, eventName, listener) {
+        mapEventListener = function (node, eventName, listener) {
             var
                 map = {},
                 index;
 
             map[eventName] = new Array(listener);
             if (listener) {
-                if (typeof (index = domElements
-                    .indexPerEquivalence(domElement)) === "number") {
+                if (typeof (index = nodes
+                    .indexPerEquivalence(node)) === "number") {
                     if (mappedListeners[index][eventName]) {
                         mappedListeners[index][eventName].push(listener);
                     } else {
                         mappedListeners[index][eventName] = map[eventName];
                     }
                 } else {
-                    domElements.push(domElement);
-                    index = domElements.length - 1;
+                    nodes.push(node);
+                    index = nodes.length - 1;
                     mappedListeners[index] = map;
                 }
             } else {
-                if (!mapped(domElement)) {
+                if (!mapped(node)) {
                     return false;
                 }
-                index = domElements.indexPerEquivalence(domElement);
+                index = nodes.indexPerEquivalence(node);
             }
 
             return mappedListeners[index][eventName];
         },
 
-        removeListener = function (domElement, eventName, listener) {
+        removeListener = function (node, eventName, listener) {
             var
-                indexObject = domElements.indexPerEquivalence(domElement),
+                indexObject = nodes.indexPerEquivalence(node),
                 listeners = mappedListeners[indexObject][eventName];
 
             listeners.delete(listener);
@@ -66,9 +66,9 @@ var
             return mappedListeners[indexObject];
         },
 
-        // removeLastListener = function (domElement, eventName, listener) {
+        // removeLastListener = function (node, eventName, listener) {
         //     var
-        //         indexObject = domElements.indexPerEquivalence(domElement),
+        //         indexObject = nodes.indexPerEquivalence(node),
         //         listeners = mappedListeners[indexObject][eventName];
 
         //     listeners.delete(listeners.last());
@@ -80,9 +80,9 @@ var
         //     return mappedListeners[indexObject];
         // },
 
-        removeListeners = function (domElement, eventName) {
+        removeListeners = function (node, eventName) {
             var
-                indexObject = domElements.indexPerEquivalence(domElement);
+                indexObject = nodes.indexPerEquivalence(node);
 
             delete mappedListeners[indexObject][eventName];
 
@@ -101,10 +101,10 @@ var
                     options = {};
                 }
 
-                self.eachAttrs(function (domElement) {
-                    mapEventListener(domElement, eventName, listener);
+                self.eachAttrs(function (node) {
+                    mapEventListener(node, eventName, listener);
 
-                    domElement.addEventListener(eventName, listener, (options.capture || false), false);
+                    node.addEventListener(eventName, listener, (options.capture || false), false);
                 });
 
                 return self;
@@ -124,21 +124,21 @@ var
                 }
 
                 if (listener) {
-                    self.eachAttrs(function (domElement) {
-                        domElement.removeEventListener(eventName, listener,
+                    self.eachAttrs(function (node) {
+                        node.removeEventListener(eventName, listener,
                             (options.capture || false));
 
-                        removeListener(domElement, eventName, listener);
+                        removeListener(node, eventName, listener);
                     });
                 } else {
-                    self.eachAttrs(function (domElement) {
-                        if (mapped(domElement)) {
-                            mapEventListener(domElement, eventName)
+                    self.eachAttrs(function (node) {
+                        if (mapped(node)) {
+                            mapEventListener(node, eventName)
                                 .forEach(function (listener) {
-                                domElement.removeEventListener(eventName,
+                                node.removeEventListener(eventName,
                                     listener, (options.capture || false));
-                                // removeLastListener(domElement, eventName);
-                                removeListeners(domElement, eventName);
+                                // removeLastListener(node, eventName);
+                                removeListeners(node, eventName);
                             });
                         }
                     });

--- a/lib/assets/javascripts/esphinx/extensor.js
+++ b/lib/assets/javascripts/esphinx/extensor.js
@@ -45,7 +45,7 @@ Extensor = (function () {
                 throw new Error("Illegal constructor");
             }
 
-            structure.eachNodes(function (answer) {
+            structure.recursiveEach(function (answer) {
                 if (answer.trail.length) {
                     context = resolveModule(answer.trail);
                 } else if (!context) {

--- a/lib/assets/javascripts/esphinx/node.js
+++ b/lib/assets/javascripts/esphinx/node.js
@@ -1,16 +1,37 @@
-//= require ./main
-
 "use strict";
 
 var
     esPhinx;
 
-(function ($module) {
+(function ($) {
 
-    $module.extend({
+    $.extend({
         prototype: {
             first: function () {
                 return this[0];
+            },
+
+            parent: function (query) {
+                var
+                    self = $(this),
+                    parent = self.first().parentNode,
+                    comparator;
+
+                if (query) {
+                    comparator = $(query).first();
+                    while (true) {
+                        if (parent.isEqualTo(comparator)) {
+                            return $(parent);
+                        } else if (!parent) {
+                            break;
+                        }
+                        parent = parent.parentNode;
+                    }
+                } else {
+                    return $(self.first().parentNode);
+                }
+
+                return $();
             }
         }
     });

--- a/lib/assets/javascripts/esphinx/observer.js
+++ b/lib/assets/javascripts/esphinx/observer.js
@@ -43,12 +43,12 @@ var
 
                 }
 
-                self.eachAttrs(function (domElement) {
+                self.eachAttrs(function (node) {
                     observer = new MutationObserver(function (mutations) {
                         callback(mutations, observer);
                     });
 
-                    observer.observe(domElement, options);
+                    observer.observe(node, options);
                 });
 
                 return self;

--- a/lib/assets/javascripts/esphinx/protector.js
+++ b/lib/assets/javascripts/esphinx/protector.js
@@ -126,12 +126,12 @@ var
                 var
                     self = this;
 
-                self.eachAttrs(function (domEl) {
-                    domEl.removeEventListener("keydown", listener,
+                self.eachAttrs(function (node) {
+                    node.removeEventListener("keydown", listener,
                         (_options.capture || false)
                     );
 
-                    domEl.addEventListener("keydown", listener,
+                    node.addEventListener("keydown", listener,
                         (_options.capture || false)
                     );
 

--- a/lib/assets/javascripts/esphinx/support/object.js
+++ b/lib/assets/javascripts/esphinx/support/object.js
@@ -147,8 +147,8 @@ var
         });
     }
 
-    if (!Object.prototype.eachNodes) {
-        $.defineProperty($.prototype, "eachNodes", {
+    if (!Object.prototype.recursiveEach) {
+        $.defineProperty($.prototype, "recursiveEach", {
             value: function (callback, trail) {
                 trail = trail || [];
 
@@ -162,9 +162,11 @@ var
                     value = self[key];
 
                     if (Object.getPrototypeOf(value) === Object.prototype) {
-                        // chamar uma função recursivamente não substitui os valores do atual loop, nem o interrompe (salvo quando a instrução return é chamada), apenas define um novo loop com um novo valor para ser executado
-                        // eachNodes(callback, trail.concat(key));
-                        value.eachNodes(callback, trail.concat(key));
+                        // call a function recursively doesn't replace values
+                        // of the current loop, neither break it, unless the return instruction is called, but just defines a new
+                        // loop with a new value to be run.
+                        // recursiveEach(callback, trail.concat(key));
+                        value.recursiveEach(callback, trail.concat(key));
                     } else {
                         callback({name: key, value: value, trail: trail});
                     }


### PR DESCRIPTION
- Renames `eachNodes` method to `recursiveEach` because compatibility case and improves the interactivity;
- Standardizes params name;

The `parent` method is a join of `parent` and `closest` methods of the `jQuery`.
